### PR TITLE
Fix Service Name, add Service

### DIFF
--- a/CitrixImagingTools/Public/Clear-AVConfiguration.ps1
+++ b/CitrixImagingTools/Public/Clear-AVConfiguration.ps1
@@ -14,7 +14,7 @@ function Clear-AVConfiguration
         
         if ($PSCmdlet.ShouldProcess('[Sophos]', '1. Stop services'))
         {
-            $Services = 'Sophos Message Router', 'Sophos Agent', 'Sophos AutoUpdate Service', 'Sophos Web Intelligence Agent'
+            $Services = 'Sophos Message Router', 'Sophos Agent', 'Sophos AutoUpdate Service', 'Sophos Web Intelligence Service', 'Sophos Web Filter'
             $Services.foreach{ Stop-Service @EA -DisplayName $_ -PassThru -Force | Set-Service -StartupType Disabled }
         }
 


### PR DESCRIPTION
* Fixes a wrong service name (already wrong  in the Sophos docs)
* Adds the Sophos Web Filter service to the list of disabled services because it constantly recreates the Web Control ID that we want to delete in step 4